### PR TITLE
Implement MSI auth

### DIFF
--- a/scripts/KeyVaultWrapper.py
+++ b/scripts/KeyVaultWrapper.py
@@ -1,15 +1,19 @@
 from azure.keyvault import KeyVaultClient
 from azure.common.credentials import ServicePrincipalCredentials
+from msrestazure.azure_active_directory import MSIAuthentication
 
 import base64
 from OpenSSL import crypto
 
 class KeyVaultWrapper(object):
-    def __init__(self, client_id, secret, tenant_id):
-        credentials = ServicePrincipalCredentials(
-                                    client_id = client_id,
-                                    secret = secret,
-                                    tenant = tenant_id)
+    def __init__(self, client_id = None, secret = None, tenant_id = None):
+        if client_id != None and secret != None and tenant_id != None:
+            credentials = ServicePrincipalCredentials(
+                                        client_id = client_id,
+                                        secret = secret,
+                                        tenant = tenant_id)
+        else:
+            credentials = MSIAuthentication(resource='https://vault.azure.net')
         self.kvclient = KeyVaultClient(credentials)
 
     def upload_secret(self, vault_uri, secret_name, filename):

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -7,4 +7,4 @@ pip install pyopenssl
 
 tar -xzf vm_scripts.tar.gz
 cd scripts
-python download_certificate.py
+python download_certificate.py &

--- a/scripts/download_certificate.py
+++ b/scripts/download_certificate.py
@@ -4,23 +4,31 @@ from OpenSSLWrapper import OpenSSLWrapper
 
 from OpenSSL import crypto
 import os
+import time
 
 hostname = os.uname()[1]
 
 cfg = Config()
 openssl = OpenSSLWrapper()
 
-kvwrapper = KeyVaultWrapper(
-    client_id = cfg.client_id, 
-    secret = cfg.secret,
-    tenant_id = cfg.tenant_id)
+def load_data():
+    kvwrapper = KeyVaultWrapper()
 
-kvwrapper.get_secret_to_file(cfg.vault_uri, 'root-ca', '', 'root_ca.pem')
-kvwrapper.get_secret_to_file(cfg.vault_uri, 'intermediate-ca', '', 'intermediate_ca.pem')
+    kvwrapper.get_secret_to_file(cfg.vault_uri, 'root-ca', '', 'root_ca.pem')
+    kvwrapper.get_secret_to_file(cfg.vault_uri, 'intermediate-ca', '', 'intermediate_ca.pem')
 
-kvwrapper.get_certificate_and_key_to_file(
-    vault_uri = cfg.vault_uri,
-    cert_name = hostname,
-    cert_version = '',
-    key_filename = 'new.key',
-    cert_filename = 'new.pem')
+    kvwrapper.get_certificate_and_key_to_file(
+        vault_uri = cfg.vault_uri,
+        cert_name = hostname,
+        cert_version = '',
+        key_filename = 'new.key',
+        cert_filename = 'new.pem')
+
+while True:
+    try:
+        load_data()
+    except:
+        time.sleep(5)
+        continue
+    else:
+        break


### PR DESCRIPTION
Allow KeyVaultWrapper to use MSIAuth if secrets aren't provided
Add retry logic to download_certificate.py
Run download_certificate.py in the background to complete VMSS extensions setup & configure the key vault.