### PR TITLE
KV access policy for VMSS, KV in different sub, improved docs, variable names cleaned up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ vm_scripts.tar.gz
 *.userosscache
 *.sln.docstates
 *.csproj.user
+*.bak
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,26 @@
 
 ## Introduction 
 
-TODO: Describe project 
+A Microsoft customer is implementing IPSec networking between all the VMs in a deployment. This project prepares the VMs in an Azure VM scale set for IPSec by installing signed digital certificates on each VM.
+
+The scale set is defined and deployed via a Terraform template. The template defines a custom script extension that downloads and runs the necessary scripts to each VM. The script files are hosted as blobs in Azure Storage.
+
+Certificates may be retrieved using one of two methods:
+
+- Pre-created certificates are securely stored in Key Vault. Access to Key Vault is secured via Managed Service Identity (MSI).
+- A certificate service creates certificates on demand. (Certificate signing can be delegated to an intermediate certificate authority (CA)).
+
+## Components
+
+- Python script that uploads the scripts to Azure
+- Docker container to generate test certificates
+- Docker container to test script download
+- A certificate generation service to generate signed certificates on demand. (Written in .NET Core so that it runs on Windows and Linux.)
+- Terraform template that provides the following:
+    - Deploys the VM scale set
+    - Specifies a custom script extension that downloads and execute the scripts on first boot
+    - Configures MSI on the VM scale set. (Note: MSI for scale sets is not yet in the official terraform-azurerm repo. A binary version of terraform-provider-azurerm is included for use until the capability is more generally supported).
+    - Creates a Key Vault access policy that gives each VM in the scale set permission to authenticate to Key Vault using MSI and retreive its certficate.
 
 ## Prerequisites
 
@@ -33,15 +52,18 @@ Config is located in ~/build/config.py. Config values must be updated with your 
 4. Replace values of storage account config properties with your storage account
 
 ### Copy scripts to storage account
+Create an archive (.tar) file containing the scripts and upload it to Azure. Also uploads a bootstrap.sh script that is executed on first launch.
 
+```
 cd <root>
 python ./build/build.py
+```
 
 ### Terraform config
 
-TODO: 
+Update the variables.tf file with configuration info from your Azure subscription. 
 
-## Build and Deploy
+## Build and Deploy Docker images to test the solution
 
 1. Open a terminal / console
 
@@ -55,13 +77,19 @@ docker-compose build
 ```
 
 3. Update ~/scripts/vm-names.json with VM names you're going to provision
-4. Create root\intermediate CAs & certs for all your VMs & uploads it to KV
+
+4. Create root\intermediate CAs & certs for all your VMs and upload them to Key Vault.
 
 ```
 docker-compose up generator
 ```
+5. Test that the secrets can be accessed via the VM scripts
 
-5. Initialize Terraform
+```
+docker-compose up worker
+```
+
+6. Initialize Terraform
 
 ```
 cd terraform
@@ -72,6 +100,12 @@ terraform init
 
 ```
 terraform apply
+```
+
+8. Debugging may require that you re-deploy the Azure infrastructure. You can do so using the following Terraform command:
+
+```
+terraform destroy
 ```
 
 # Contributing

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -1,7 +1,8 @@
 class Config(object):
     def __init__(self):
+        # Use the values from the subscription hosting your KeyVault instance.
         self.client_id = ""
         self.secret = ""
-        self.tenant_id = ''
+        self.tenant_id = ""
         
         self.vault_uri = ""

--- a/scripts/vm_names.json
+++ b/scripts/vm_names.json
@@ -1,10 +1,10 @@
 [
-    {"vmName": "vm000000"},
-    {"vmName": "vm000001"},
-    {"vmName": "vm000002"},
-    {"vmName": "vm000003"},
-    {"vmName": "vm000004"},
-    {"vmName": "vm000005"},
-    {"vmName": "vm000006"},
-    {"vmName": "vm000007"}
+    {"vmName": "vmss-certs-000000"},
+    {"vmName": "vmss-certs-000001"},
+    {"vmName": "vmss-certs-000002"},
+    {"vmName": "vmss-certs-000003"},
+    {"vmName": "vmss-certs-000004"},
+    {"vmName": "vmss-certs-000005"},
+    {"vmName": "vmss-certs-000006"},
+    {"vmName": "vmss-certs-000007"}
 ]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,6 +5,14 @@ provider "azurerm" {
   tenant_id       = "${var.tenant_id}"
 }
     
+provider "azurerm" {
+  alias           = "key_vault_subscription"
+  subscription_id = "${var.key_vault_subscription_id}"
+  client_id       = "${var.client_id}"
+  client_secret   = "${var.client_secret}"
+  tenant_id       = "${var.tenant_id}"
+}
+    
 resource "azurerm_resource_group" "rg" {
   name     = "${var.resource_group_name}"
   location = "${var.location}"
@@ -25,11 +33,11 @@ resource "azurerm_subnet" "subnet" {
 }
 
 resource "azurerm_public_ip" "pip" {
-  name                         = "${var.hostname}-pip"
+  name                         = "${var.vmss_prefix}-pip"
   location                     = "${azurerm_resource_group.rg.location}"
   resource_group_name          = "${azurerm_resource_group.rg.name}"
   public_ip_address_allocation = "Dynamic"
-  domain_name_label            = "${var.hostname}"
+  domain_name_label            = "${var.vmss_prefix}"
 }
 
 resource "azurerm_lb" "lb" {
@@ -61,8 +69,8 @@ resource "azurerm_lb_nat_pool" "np" {
   frontend_ip_configuration_name = "LBFrontEnd"
 }
 
-resource "azurerm_storage_account" "stor" {
-  name                     = "${var.resource_group_name}stor"
+resource "azurerm_storage_account" "store" {
+  name                     = "${var.resource_group_name}store"
   location                 = "${azurerm_resource_group.rg.location}"
   resource_group_name      = "${azurerm_resource_group.rg.name}"
   account_tier             = "${var.storage_account_tier}"
@@ -72,12 +80,12 @@ resource "azurerm_storage_account" "stor" {
 resource "azurerm_storage_container" "vhds" {
   name                  = "vhds"
   resource_group_name   = "${azurerm_resource_group.rg.name}"
-  storage_account_name  = "${azurerm_storage_account.stor.name}"
+  storage_account_name  = "${azurerm_storage_account.store.name}"
   container_access_type = "blob"
 }
 
 resource "azurerm_virtual_machine_scale_set" "scaleset" {
-  name                = "autoscalewad"
+  name                = "vmscaleset"
   location            = "${azurerm_resource_group.rg.location}"
   resource_group_name = "${azurerm_resource_group.rg.name}"
   upgrade_policy_mode = "Manual"
@@ -99,13 +107,11 @@ resource "azurerm_virtual_machine_scale_set" "scaleset" {
     publisher                  = "Microsoft.ManagedIdentity"
     type                       = "ManagedIdentityExtensionForLinux"
     type_handler_version       = "1.0"
-    auto_upgrade_minor_version = true
     settings                   = "{\"port\": 50342}"
-    protected_settings         = "{}"
   }
 
   os_profile {
-    computer_name_prefix = "${var.vmss_name_prefix}"
+    computer_name_prefix = "${var.vmss_prefix}-"
     admin_username       = "${var.admin_username}"
     admin_password       = "${var.admin_password}"
   }
@@ -115,11 +121,11 @@ resource "azurerm_virtual_machine_scale_set" "scaleset" {
   }
 
   network_profile {
-    name    = "${var.hostname}-nic"
+    name    = "${var.vmss_prefix}-nic"
     primary = true
 
     ip_configuration {
-      name                                   = "${var.hostname}ipconfig"
+      name                                   = "${var.vmss_prefix}-ipconfig"
       subnet_id                              = "${azurerm_subnet.subnet.id}"
       load_balancer_backend_address_pool_ids = ["${azurerm_lb_backend_address_pool.backlb.id}"]
       load_balancer_inbound_nat_rules_ids    = ["${element(azurerm_lb_nat_pool.np.*.id, count.index)}"]
@@ -127,10 +133,10 @@ resource "azurerm_virtual_machine_scale_set" "scaleset" {
   }
 
   storage_profile_os_disk {
-    name           = "${var.hostname}"
+    name           = "${var.vmss_prefix}"
     caching        = "ReadWrite"
     create_option  = "FromImage"
-    vhd_containers = ["${azurerm_storage_account.stor.primary_blob_endpoint}${azurerm_storage_container.vhds.name}"]
+    vhd_containers = ["${azurerm_storage_account.store.primary_blob_endpoint}${azurerm_storage_container.vhds.name}"]
   }
 
   storage_profile_image_reference {
@@ -147,38 +153,73 @@ resource "azurerm_virtual_machine_scale_set" "scaleset" {
     type_handler_version    = "2.0"
     settings                = <<SETTINGS
         {
-         "commandToExecute": "cmd",
+          "commandToExecute": "${var.command}",
           "fileUris": [
-            "https://<storagename>.blob.core.windows.net/<file>",
+            "${var.file1}",
+            "${var.file2}"
           ]
         }
       SETTINGS
   }
 }
 
+# IMPLEMENTATION NOTE: The Terraform AzureRM provider does not currently support access policies
+# as resources. While you can specify an access policy as part of a Key Vault resource definition,
+# destroying the resource deletes the entire Key Vault, which must not happen. We work around 
+# this issue by using an ARM template to define the access policy. During a destroy, Terraform 
+# deletes the ARM template, but that has no impact on the underlying resources created by the ARM
+# template. 
+#
+# A "proper" solution is to implement access policies as first-class resources in the AzureRM 
+# Terraform provider. This work-around is fine for now, however.
 
-resource "azurerm_key_vault" "kv" {
+resource "azurerm_template_deployment" "access_policy" {
+  provider            = "azurerm.key_vault_subscription"
+  name                = "set_KV_access_policy"
+  resource_group_name = "${var.key_vault_resource_group_name}"
+  deployment_mode     = "Incremental"
   depends_on          = ["azurerm_virtual_machine_scale_set.scaleset"]
-  name                = "<KV name>"
-  location            = "${var.location}"
-  resource_group_name = "<KV RG>"
 
-  sku {
-    name = "standard"
-  }
+  template_body = <<DEPLOY
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "name": "${var.key_vault_name}",
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2016-10-01",
+      "location": "${var.key_vault_location}",
+      "tags": {},
 
-  tenant_id = "${var.tenant_id}"
+      "properties": {
+        "enabledForDeployment": true,
+        "enabledForDiskEncryption": false,
+        "enabledForTemplateDeployment": true,
+        "createMode": "incremental",
 
-  access_policy {
-    tenant_id = "${var.tenant_id}"
-    object_id = "${lookup(azurerm_virtual_machine_scale_set.scaleset.identity[0], "principal_id")}"
+        "tenantId": "${var.tenant_id}",
 
-    key_permissions = [
-      
-    ]
+        "sku":{
+          "family": "A",
+          "name": "standard"
+        },
 
-    secret_permissions = [
-      "get",
-    ]
-  }
+        "accessPolicies": [
+          {
+            "tenantId": "${var.tenant_id}",
+            "objectId": "${lookup(azurerm_virtual_machine_scale_set.scaleset.identity[0], "principal_id")}",
+            "applicationId": "${var.client_id}",
+            "permissions": {
+              "secrets": [
+                "get"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+DEPLOY
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,3 @@
-output "hostname" {
-  value = "${var.vmss_name_prefix}"
+output "VMSS SPN" {
+  value = "${lookup(azurerm_virtual_machine_scale_set.scaleset.identity[0], "principal_id")}"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,12 +1,19 @@
-variable "subscription_id" {
-  default = ""
-}
+###############################################################################
+# Shared Variables
+###############################################################################
 
+# Add this application to the subscriptions' IAM with permission to create resources
+# NOTE: Add the app to BOTH the scale set's and key vault's subscription
+# (if they are different)
+#
+# Use this same value as the client_id in scripts/config.py (used by cert Generator)
 variable "client_id" {
+  description = "Application ID value from an Active Directory App Registration."
   default = ""
 }
 
 variable "client_secret" {
+  description = "Secret value obtained by creating a key for the App Registration."
   default = ""
 }
 
@@ -15,13 +22,42 @@ variable "tenant_id" {
   default = ""
 }
 
+###############################################################################
+# Key Vault Variables
+###############################################################################
+variable "key_vault_subscription_id" {
+  default = ""
+}
+
+variable "key_vault_resource_group_name" {
+  description = "The name of the resource group in which to create the virtual network."
+  default = ""
+}
+
+variable "key_vault_location" {
+  description = "The location/region where the virtual network is created. Changing this forces a new resource to be created."
+  default     = ""
+}
+
+variable "key_vault_name" {
+  default = ""
+}
+
+###############################################################################
+# Scale Set Variables
+###############################################################################
+variable "subscription_id" {
+  default = ""
+}
+
 variable "resource_group_name" {
   description = "The name of the resource group in which to create the virtual network."
+  default = ""
 }
 
 variable "location" {
   description = "The location/region where the virtual network is created. Changing this forces a new resource to be created."
-  default     = "southcentralus"
+  default     = ""
 }
 
 variable "storage_account_tier" {
@@ -34,7 +70,7 @@ variable "storage_replication_type" {
   default     = "LRS"
 }
 
-variable "hostname" {
+variable "vmss_prefix" {
   default = ""
 }
 
@@ -71,4 +107,16 @@ variable "admin_username" {
 
 variable "admin_password" {
   default = ""
+}
+
+variable "command" {
+  default = "bash bootstrap.sh"
+}
+
+variable "file1" {
+  default = "https://<storage_name>.blob.core.windows.net/vm-scripts-files/bootstrap.sh"
+}
+
+variable "file2" {
+  default = "https://<storage_name>.blob.core.windows.net/vm-scripts-files/vm_scripts.tar.gz"
 }


### PR DESCRIPTION
Summary:

- ARM template resource added to give newly provisioned scale set access to read secrets from KV
- Terraform templates updated to support Key Vault in a different/remote subscription
- Improved docs/usability via updates to README.md, comments in Terraform templates, cleaning up names in templates