### PR TITLE
Removed extra line that was messing up how policy is set.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -209,7 +209,6 @@ resource "azurerm_template_deployment" "access_policy" {
           {
             "tenantId": "${var.tenant_id}",
             "objectId": "${lookup(azurerm_virtual_machine_scale_set.scaleset.identity[0], "principal_id")}",
-            "applicationId": "${var.client_id}",
             "permissions": {
               "secrets": [
                 "get"


### PR DESCRIPTION
The SPN is passed object_id. I was specifying application_id thinking it was required to give the template write permissions, when in fact those permissions are already granted at the resource level. KV was still accepting the request but the value is corrupted. (Probably a validation bug on the KV resource provider.)